### PR TITLE
[PKG-5097] Update to 0.30.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,6 +83,11 @@ outputs:
         - numpy >=1.22.4,<2
         - fsspec >=2022.11.0
         - psutil >=5.8.0
+      run_constrained:
+      # numexpr 2.8.5 breaks pandas, see below for context:
+      # https://github.com/modin-project/modin/pull/7296
+      # https://github.com/modin-project/modin/issues/6469
+        - numexpr !=2.8.5
     test:
       source_files:
         - modin

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -142,8 +142,8 @@ outputs:
       run:
         - python
         - {{ pin_subpackage('modin-core', exact=True) }}
-        - ray-default >=1.13.0,!=2.5.0
-        - pyarrow >=7.0.0
+        - ray-default >=2.1.0,!=2.5.0
+        - pyarrow >=10.0.1
         - async-timeout
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.28.1" %}
+{% set version = "0.30.1" %}
 
 package:
   name: modin-packages
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/modin-project/modin/archive/refs/tags/{{ version }}.tar.gz
-  sha256: f705b0a11b0569e5ad032d2abed310b2bb61bfdd5f0b29192a8a2881ebde4ed0
+  sha256: 3f4bbad4b05e1aedd30062fd2b6fd4cc02bc8f4066d4d2c790557da82cdb1d2f
   # The vendored versioneer.py uses deprecated configparser.SafeConfigParser, causing build to fail on 3.12
   patches:  # [py>=312]
     - update_versioneer.patch # [py>=312]
@@ -79,8 +79,8 @@ outputs:
       run:
         - python
         - packaging >=21.0
-        - pandas ==2.2.1
-        - numpy >=1.22.4
+        - pandas >=2.2,<2.3
+        - numpy >=1.22.4,<2
         - fsspec >=2022.11.0
         - psutil >=5.8.0
     test:
@@ -93,24 +93,25 @@ outputs:
         - pip
         - distributed >=2.22.0
         - dask >=2.22.0
-        - pytest
+        - pytest >=7.3.2
         - boto3
         - requests
-        - matplotlib-base >=3.6.1
+        - matplotlib-base >=3.6.3
         - xarray >=2022.03.0
-        - pyarrow >=7.0.0
-        - s3fs >=2022.05.0
+        - pyarrow >=10.0.1
+        - s3fs >=2022.11.0
         - numexpr <2.8.5  # [py<312]
+        - scipy >=1.10
 
       commands:
         # Skip pip check on win due to strict dependency in docker-py
         - pip check  # [not win]
         # Running subset of tests sourced from https://github.com/modin-project/modin/blob/0.26.1/.github/workflows/ci.yml#L535
-        - pytest modin/pandas/test/dataframe/test_udf.py  # [py<312]
-        - pytest modin/pandas/test/dataframe/test_reduce.py modin/pandas/test/dataframe/test_window.py modin/pandas/test/dataframe/test_pickle.py modin/pandas/test/dataframe/test_binary.py modin/pandas/test/dataframe/test_iter.py  # [not win]
-        - pytest -m "not exclude_in_sanity" modin/pandas/test/test_series.py
-        - pytest -m "not exclude_in_sanity" modin/pandas/test/dataframe/test_map_metadata.py modin/pandas/test/test_expanding.py modin/pandas/test/test_reshape.py modin/pandas/test/test_general.py modin/pandas/test/test_concat.py  # [not win]
-        - pytest modin/test/interchange/dataframe_protocol/test_general.py modin/pandas/test/test_concat.py modin/test/interchange/dataframe_protocol/pandas/test_protocol.py modin/pandas/test/test_rolling.py
+        - pytest modin/tests/pandas/dataframe/test_udf.py  # [py<312]
+        - pytest modin/tests/pandas/dataframe/test_reduce.py modin/tests/pandas/dataframe/test_window.py modin/tests/pandas/dataframe/test_pickle.py modin/tests/pandas/dataframe/test_binary.py modin/tests/pandas/dataframe/test_iter.py  # [not win]
+        - pytest -m "not exclude_in_sanity" modin/tests/pandas/test_series.py -k "not cat_categories"
+        - pytest -m "not exclude_in_sanity" modin/tests/pandas/dataframe/test_map_metadata.py modin/tests/pandas/test_expanding.py modin/tests/pandas/test_reshape.py modin/tests/pandas/test_general.py modin/tests/pandas/test_concat.py  # [not win]
+        - pytest modin/tests/interchange/dataframe_protocol/test_general.py modin/tests/pandas/test_concat.py modin/tests/interchange/dataframe_protocol/pandas/test_protocol.py modin/tests/pandas/test_rolling.py
 
   - name: modin-dask
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -144,6 +144,7 @@ outputs:
         - {{ pin_subpackage('modin-core', exact=True) }}
         - ray-default >=1.13.0,!=2.5.0
         - pyarrow >=7.0.0
+        - async-timeout
     test:
       imports:
         - modin

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -144,6 +144,8 @@ outputs:
         - {{ pin_subpackage('modin-core', exact=True) }}
         - ray-default >=2.1.0,!=2.5.0
         - pyarrow >=10.0.1
+        # ray-core is missing async-timeout.
+        # Once that's fixed, we can remove this dependency.
         - async-timeout
     test:
       imports:


### PR DESCRIPTION
modin 0.30.1

**Destination channel:** defaults

### Links

- [PKG-5097] 
- [Upstream repository](https://github.com/modin-project/modin/tree/0.30.1)
- [Upstream changelog/diff](https://github.com/modin-project/modin/compare/0.28.1...0.30.1)

### Explanation of changes:

- Adjust test commands for relocated test files.
- Add `async-timeout` to `modin-ray`. 
- Update dependency pinnings.
- Confirmed that `versioneer` patch is still necessary for python 3.12


[PKG-5097]: https://anaconda.atlassian.net/browse/PKG-5097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ