### PR TITLE
modin 0.37.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "modin" %}
-{% set version = "0.36.0" %}
+{% set version = "0.37.1" %}
 
 package:
   name: {{ name }}-packages
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/modin-project/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 0bb711cdd0b294cd47e81e3c5e96c584b45ceda2900aca8b802ad07cd11d0ea5
+  sha256: da7f313a8a7ba5453d195b98ce7be2b25e66099693c117904aa2865606233702
 
 build:
   number: 0
@@ -19,7 +19,7 @@ requirements:
     - setuptools
 
 # the outputs map the modin extras on PyPI (see upstream definition
-# https://github.com/modin-project/modin/blob/0.36.0/setup.py#L60-L64)
+# https://github.com/modin-project/modin/blob/0.37.1/setup.py#L61-L65)
 # from "modin[<extra>]" to "modin-<extra>" as a conda-forge package.
 outputs:
   - name: modin-all
@@ -79,6 +79,7 @@ outputs:
         - numpy >=1.22.4
         - fsspec >=2022.11.0
         - psutil >=5.8.0
+        - typing_extensions
       run_constrained:
         # numexpr 2.8.5 breaks pandas, see below for context:
         # https://github.com/modin-project/modin/pull/7296
@@ -115,7 +116,7 @@ outputs:
         - typing_extensions
       commands:
         - pip check
-        # Running subset of tests sourced from https://github.com/modin-project/modin/blob/0.35.0/.github/workflows/ci.yml#L643-L704
+        # Running subset of tests sourced from https://github.com/modin-project/modin/blob/0.37.1/.github/workflows/ci.yml#L643-L704
         - pytest modin/tests/pandas/test_rolling.py
         - pytest modin/tests/pandas/test_expanding.py
         - pytest modin/tests/pandas/test_reshape.py


### PR DESCRIPTION
modin 0.37.1 

**Destination channel:** Defaults

### Links

- [PKG-10068]
- dev_url:        https://github.com/modin-project/modin/tree/0.37.1
- conda_forge:    https://github.com/conda-forge/modin-feedstock
- pypi:           https://pypi.org/project/modin/0.37.1
- pypi inspector: https://inspector.pypi.io/project/modin/0.37.1

### Explanation of changes:

- new version number


[PKG-10068]: https://anaconda.atlassian.net/browse/PKG-10068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ